### PR TITLE
Poster-regist#22

### DIFF
--- a/src/main/java/study/movieservice/controller/MainController.java
+++ b/src/main/java/study/movieservice/controller/MainController.java
@@ -3,9 +3,11 @@ package study.movieservice.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import study.movieservice.domain.movie.Movie;
 import study.movieservice.service.MovieService;
 import static study.movieservice.domain.ExceptionMessageConst.SUCCESS_SAVE_MOVIE;
+import static study.movieservice.domain.ExceptionMessageConst.SUCCESS_SAVE_POSTER;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,8 +18,14 @@ public class MainController {
 
     @PostMapping("/save-movies")
     @ResponseStatus(HttpStatus.OK)
-    public String memberJoin(@RequestBody Movie movie) {
+    public String movieJoin(@RequestBody Movie movie) {
         movieService.addMovie(movie);
         return SUCCESS_SAVE_MOVIE.getMessage();
+    }
+    @PostMapping("/save-poster")
+    @ResponseStatus(HttpStatus.OK)
+    public String posterJoin(@RequestPart MultipartFile file,@RequestPart Long movieId){
+        movieService.addPoster(file,movieId);
+        return SUCCESS_SAVE_POSTER.getMessage();
     }
 }

--- a/src/main/java/study/movieservice/controller/MainController.java
+++ b/src/main/java/study/movieservice/controller/MainController.java
@@ -17,13 +17,13 @@ public class MainController {
     private final MovieService movieService;
 
     @PostMapping("/save-movies")
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.CREATED)
     public String movieJoin(@RequestBody Movie movie) {
         movieService.addMovie(movie);
         return SUCCESS_SAVE_MOVIE.getMessage();
     }
     @PostMapping("/save-poster")
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.CREATED)
     public String posterJoin(@RequestPart MultipartFile file,@RequestPart Long movieId){
         movieService.addPoster(file,movieId);
         return SUCCESS_SAVE_POSTER.getMessage();

--- a/src/main/java/study/movieservice/domain/ExceptionMessageConst.java
+++ b/src/main/java/study/movieservice/domain/ExceptionMessageConst.java
@@ -22,7 +22,9 @@ public enum ExceptionMessageConst {
 
     SUCCESS_SIGN_UP("회원가입이 완료되었습니다."),
 
-    SUCCESS_SAVE_MOVIE("영화등록이 완료되었습니다.");
+    SUCCESS_SAVE_MOVIE("영화등록이 완료되었습니다."),
+    SUCCESS_SAVE_POSTER("포스터등록이 완료되었습니다."),
+    FAILED_FILE_RECEIVE("파일을 불러오는데 실패했습니다. 다시한번 확인해주세요");
 
     private final String message;
 }

--- a/src/main/java/study/movieservice/domain/movie/Poster.java
+++ b/src/main/java/study/movieservice/domain/movie/Poster.java
@@ -1,0 +1,12 @@
+package study.movieservice.domain.movie;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Poster {
+    private final Long posterId;
+    private final Long movieId;
+    private final String saveFilePath;
+}

--- a/src/main/java/study/movieservice/repository/MovieMapper.java
+++ b/src/main/java/study/movieservice/repository/MovieMapper.java
@@ -2,10 +2,12 @@ package study.movieservice.repository;
 
 import org.apache.ibatis.annotations.Mapper;
 import study.movieservice.domain.movie.Movie;
+import study.movieservice.domain.movie.Poster;
 
 @Mapper
 public interface MovieMapper {
 
     void save(Movie movie);
 
+    void savePoster(Poster poster);
 }

--- a/src/main/java/study/movieservice/repository/MovieMapper.java
+++ b/src/main/java/study/movieservice/repository/MovieMapper.java
@@ -2,12 +2,9 @@ package study.movieservice.repository;
 
 import org.apache.ibatis.annotations.Mapper;
 import study.movieservice.domain.movie.Movie;
-import study.movieservice.domain.movie.Poster;
 
 @Mapper
 public interface MovieMapper {
 
     void save(Movie movie);
-
-    void savePoster(Poster poster);
 }

--- a/src/main/java/study/movieservice/repository/PosterMapper.java
+++ b/src/main/java/study/movieservice/repository/PosterMapper.java
@@ -1,0 +1,10 @@
+package study.movieservice.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import study.movieservice.domain.movie.Poster;
+
+@Mapper
+public interface PosterMapper {
+
+    void savePoster(Poster poster);
+}

--- a/src/main/java/study/movieservice/service/MovieService.java
+++ b/src/main/java/study/movieservice/service/MovieService.java
@@ -1,15 +1,26 @@
 package study.movieservice.service;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import study.movieservice.domain.movie.Movie;
+import study.movieservice.domain.movie.Poster;
 import study.movieservice.repository.MovieMapper;
+import java.io.File;
+import java.io.IOException;
+
+import static study.movieservice.domain.ExceptionMessageConst.FAILED_FILE_RECEIVE;
 
 @Service
-@RequiredArgsConstructor
 public class MovieService {
 
     private final MovieMapper movieMapper;
+    private final String fixedPath;
+
+    public MovieService(MovieMapper movieMapper,@Value("${fixedPath}") String fixedPath) {
+        this.movieMapper = movieMapper;
+        this.fixedPath = fixedPath;
+    }
 
     public void addMovie(Movie inputMovie){
         Movie movie = Movie.builder()
@@ -21,5 +32,23 @@ public class MovieService {
                 .openingDate(inputMovie.getOpeningDate()).build();
 
         movieMapper.save(movie);
+    }
+
+    public void addPoster(MultipartFile file,Long movieId){
+
+        String originalFileName=file.getOriginalFilename();
+        String FilePath=fixedPath+originalFileName;
+        File destination=new File(FilePath);
+
+        Poster poster = Poster.builder()
+                .movieId(movieId)
+                .saveFilePath(FilePath).build();
+
+        try {
+            file.transferTo(destination);
+            movieMapper.savePoster(poster);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
+        }
     }
 }

--- a/src/main/java/study/movieservice/service/MovieService.java
+++ b/src/main/java/study/movieservice/service/MovieService.java
@@ -1,25 +1,25 @@
 package study.movieservice.service;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import study.movieservice.domain.movie.Movie;
 import study.movieservice.domain.movie.Poster;
 import study.movieservice.repository.MovieMapper;
-import java.io.File;
-import java.io.IOException;
-
-import static study.movieservice.domain.ExceptionMessageConst.FAILED_FILE_RECEIVE;
+import study.movieservice.repository.PosterMapper;
+import study.movieservice.service.fileIO.FileIO;
+import study.movieservice.service.fileIO.FileIOLocal;
 
 @Service
 public class MovieService {
 
     private final MovieMapper movieMapper;
-    private final String fixedPath;
+    private final PosterMapper posterMapper;
+    private final FileIO fileIO;
 
-    public MovieService(MovieMapper movieMapper,@Value("${fixedPath}") String fixedPath) {
+    public MovieService(MovieMapper movieMapper, PosterMapper posterMapper, FileIOLocal fileIOLocal) {
         this.movieMapper = movieMapper;
-        this.fixedPath = fixedPath;
+        this.posterMapper=posterMapper;
+        this.fileIO=fileIOLocal;
     }
 
     public void addMovie(Movie movie){
@@ -28,25 +28,11 @@ public class MovieService {
 
     public void addPoster(MultipartFile file,Long movieId){
 
-        String FilePath=saveFile(file);
+        String FilePath= fileIO.saveFile(file);
 
         Poster poster = Poster.builder()
                 .movieId(movieId)
                 .saveFilePath(FilePath).build();
-        movieMapper.savePoster(poster);
-    }
-
-    public String saveFile(MultipartFile file){
-
-        String originalFileName=file.getOriginalFilename();
-        String FilePath=fixedPath+originalFileName;
-        File destination=new File(FilePath);
-
-        try {
-            file.transferTo(destination);
-        } catch (IOException e) {
-            throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
-        }
-        return FilePath;
+        posterMapper.savePoster(poster);
     }
 }

--- a/src/main/java/study/movieservice/service/MovieService.java
+++ b/src/main/java/study/movieservice/service/MovieService.java
@@ -22,33 +22,31 @@ public class MovieService {
         this.fixedPath = fixedPath;
     }
 
-    public void addMovie(Movie inputMovie){
-        Movie movie = Movie.builder()
-                .movieName(inputMovie.getMovieName())
-                .genre(inputMovie.getGenre())
-                .actor(inputMovie.getActor())
-                .runningTime(inputMovie.getRunningTime())
-                .supervisor(inputMovie.getSupervisor())
-                .openingDate(inputMovie.getOpeningDate()).build();
-
+    public void addMovie(Movie movie){
         movieMapper.save(movie);
     }
 
     public void addPoster(MultipartFile file,Long movieId){
 
-        String originalFileName=file.getOriginalFilename();
-        String FilePath=fixedPath+originalFileName;
-        File destination=new File(FilePath);
+        String FilePath=saveFile(file);
 
         Poster poster = Poster.builder()
                 .movieId(movieId)
                 .saveFilePath(FilePath).build();
+        movieMapper.savePoster(poster);
+    }
+
+    public String saveFile(MultipartFile file){
+
+        String originalFileName=file.getOriginalFilename();
+        String FilePath=fixedPath+originalFileName;
+        File destination=new File(FilePath);
 
         try {
             file.transferTo(destination);
-            movieMapper.savePoster(poster);
         } catch (IOException e) {
             throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
         }
+        return FilePath;
     }
 }

--- a/src/main/java/study/movieservice/service/MovieService.java
+++ b/src/main/java/study/movieservice/service/MovieService.java
@@ -24,15 +24,18 @@ public class MovieService {
     }
 
     public void addPoster(MultipartFile file, Long movieId) {
-        try {
-            String FilePath = fileIO.uploadFile(file);
-            Poster poster = Poster.builder()
-                    .movieId(movieId)
-                    .saveFilePath(FilePath).build();
+        String filePath;
 
-            posterMapper.savePoster(poster);
+        try {
+            filePath = fileIO.uploadFile(file);
         } catch (IOException e) {
             throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
         }
+
+        Poster poster = Poster.builder()
+                .movieId(movieId)
+                .saveFilePath(filePath).build();
+
+        posterMapper.savePoster(poster);
     }
 }

--- a/src/main/java/study/movieservice/service/MovieService.java
+++ b/src/main/java/study/movieservice/service/MovieService.java
@@ -1,5 +1,6 @@
 package study.movieservice.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import study.movieservice.domain.movie.Movie;
@@ -7,32 +8,31 @@ import study.movieservice.domain.movie.Poster;
 import study.movieservice.repository.MovieMapper;
 import study.movieservice.repository.PosterMapper;
 import study.movieservice.service.fileIO.FileIO;
-import study.movieservice.service.fileIO.FileIOLocal;
+import java.io.IOException;
+import static study.movieservice.domain.ExceptionMessageConst.FAILED_FILE_RECEIVE;
 
 @Service
+@RequiredArgsConstructor
 public class MovieService {
 
     private final MovieMapper movieMapper;
     private final PosterMapper posterMapper;
     private final FileIO fileIO;
 
-    public MovieService(MovieMapper movieMapper, PosterMapper posterMapper, FileIOLocal fileIOLocal) {
-        this.movieMapper = movieMapper;
-        this.posterMapper=posterMapper;
-        this.fileIO=fileIOLocal;
-    }
-
-    public void addMovie(Movie movie){
+    public void addMovie(Movie movie) {
         movieMapper.save(movie);
     }
 
-    public void addPoster(MultipartFile file,Long movieId){
+    public void addPoster(MultipartFile file, Long movieId) {
+        try {
+            String FilePath = fileIO.uploadFile(file);
+            Poster poster = Poster.builder()
+                    .movieId(movieId)
+                    .saveFilePath(FilePath).build();
 
-        String FilePath= fileIO.saveFile(file);
-
-        Poster poster = Poster.builder()
-                .movieId(movieId)
-                .saveFilePath(FilePath).build();
-        posterMapper.savePoster(poster);
+            posterMapper.savePoster(poster);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
+        }
     }
 }

--- a/src/main/java/study/movieservice/service/fileIO/FileIO.java
+++ b/src/main/java/study/movieservice/service/fileIO/FileIO.java
@@ -2,6 +2,8 @@ package study.movieservice.service.fileIO;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 public interface FileIO {
-    String saveFile(MultipartFile file);
+    String uploadFile(MultipartFile file)throws IOException;
 }

--- a/src/main/java/study/movieservice/service/fileIO/FileIO.java
+++ b/src/main/java/study/movieservice/service/fileIO/FileIO.java
@@ -1,0 +1,7 @@
+package study.movieservice.service.fileIO;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileIO {
+    String saveFile(MultipartFile file);
+}

--- a/src/main/java/study/movieservice/service/fileIO/FileIOLocal.java
+++ b/src/main/java/study/movieservice/service/fileIO/FileIOLocal.java
@@ -1,13 +1,12 @@
 package study.movieservice.service.fileIO;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.IOException;
-import static study.movieservice.domain.ExceptionMessageConst.FAILED_FILE_RECEIVE;
 
-@Component
+@Service
 public class FileIOLocal implements FileIO {
 
     private final String fixedPath;
@@ -17,17 +16,14 @@ public class FileIOLocal implements FileIO {
     }
 
     @Override
-    public String saveFile(MultipartFile file) {
+    public String uploadFile(MultipartFile file) throws IOException {
 
-        String originalFileName=file.getOriginalFilename();
-        String FilePath=fixedPath+originalFileName;
-        File destination=new File(FilePath);
+        String originalFileName = file.getOriginalFilename();
+        String FilePath = fixedPath + originalFileName;
+        File destination = new File(FilePath);
 
-        try {
-            file.transferTo(destination);
-        } catch (IOException e) {
-            throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
-        }
+        file.transferTo(destination);
+
         return FilePath;
     }
 }

--- a/src/main/java/study/movieservice/service/fileIO/FileIOLocal.java
+++ b/src/main/java/study/movieservice/service/fileIO/FileIOLocal.java
@@ -1,0 +1,33 @@
+package study.movieservice.service.fileIO;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.File;
+import java.io.IOException;
+import static study.movieservice.domain.ExceptionMessageConst.FAILED_FILE_RECEIVE;
+
+@Component
+public class FileIOLocal implements FileIO {
+
+    private final String fixedPath;
+
+    public FileIOLocal(@Value("${fixedPath}") String fixedPath) {
+        this.fixedPath = fixedPath;
+    }
+
+    @Override
+    public String saveFile(MultipartFile file) {
+
+        String originalFileName=file.getOriginalFilename();
+        String FilePath=fixedPath+originalFileName;
+        File destination=new File(FilePath);
+
+        try {
+            file.transferTo(destination);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
+        }
+        return FilePath;
+    }
+}

--- a/src/main/resources/study/movieservice/repository/MovieMapper.xml
+++ b/src/main/resources/study/movieservice/repository/MovieMapper.xml
@@ -6,5 +6,10 @@
         insert into movie(movie_name, genre, actor, running_time, supervisor, opening_date, updated_at, created_at)
         values (#{movieName}, #{genre}, #{actor}, #{runningTime},#{supervisor}, #{openingDate}, current_timestamp , current_timestamp)
     </insert>
+
+    <insert id="savePoster" useGeneratedKeys="true" keyProperty="posterId">
+        insert into poster(movie_id, save_file_path, updated_at, created_at)
+        values (#{movieId}, #{saveFilePath}, current_timestamp , current_timestamp)
+    </insert>
 </mapper>
 

--- a/src/main/resources/study/movieservice/repository/PosterMapper.xml
+++ b/src/main/resources/study/movieservice/repository/PosterMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="study.movieservice.repository.PosterMapper">
+    <insert id="savePoster" useGeneratedKeys="true" keyProperty="posterId">
+        insert into poster(movie_id, save_file_path, updated_at, created_at)
+        values (#{movieId}, #{saveFilePath}, current_timestamp , current_timestamp)
+    </insert>
+</mapper>
+


### PR DESCRIPTION
> ## 포스터 등록 기능 구현

#### - MainController에서 poster 이미지 등록을 저장하는 posterJoin이 추가되었습니다.
## MainController.java
``` java
    @PostMapping("/save-poster")
    @ResponseStatus(HttpStatus.OK)
    public String posterJoin(@RequestPart MultipartFile file,@RequestPart Long movieId){
        movieService.addPoster(file,movieId);
        return SUCCESS_SAVE_POSTER.getMessage();
    }
```
#### - poster 등록을 위해 새로운 poster관련 쿼리를 추가하였습니다.
## MovieMapper.xml
```
    <insert id="savePoster" useGeneratedKeys="true" keyProperty="posterId">
        insert into poster(movie_id, save_file_path, updated_at, created_at)
        values (#{movieId}, #{saveFilePath}, current_timestamp , current_timestamp)
    </insert>
```
#### - poster 등록을 처리하는 addPoster 메소드를 비지니스 로직에 추가하였습니다.
## MovieService.java
```java
   public void addPoster(MultipartFile file,Long movieId){

        String originalFileName=file.getOriginalFilename();
        String FilePath=fixedPath+originalFileName;
        File destination=new File(FilePath);

        Poster poster = Poster.builder()
                .movieId(movieId)
                .saveFilePath(FilePath).build();

        try {
            file.transferTo(destination);
            movieMapper.savePoster(poster);
        } catch (IOException e) {
            throw new IllegalArgumentException(FAILED_FILE_RECEIVE.getMessage());
        }
    }
```
#### - 이미지들이 저장될 경로를 properties에 넣어 fixedPath로 값을 받아오기 위해 @RequiredArgsConstructor를 사용하던것을 제거하고 생성자를 변경하였습니다.
## MovieService.java
```java
    public MovieService(MovieMapper movieMapper,@Value("${fixedPath}") String fixedPath) {
        this.movieMapper = movieMapper;
        this.fixedPath = fixedPath;
    }
```
