### PR TITLE
review와 recommend의 soft delete 변경 #45

### DIFF
--- a/src/main/java/study/movieservice/service/RecommendService.java
+++ b/src/main/java/study/movieservice/service/RecommendService.java
@@ -85,6 +85,14 @@ public class RecommendService {
 
         if (!recommendMapper.findByReviewIdAndMemberId(reviewId, memberId))
             throw new IllegalArgumentException(FAILED_RECOMMEND_REQUEST.getMessage());
+
+        if(inputRecommend.getRecommendState()) {
+            reviewService.decreaseLikeCount(reviewId);
+        }
+        else{
+            reviewService.decreaseDislikeCount(reviewId);
+        }
+
         recommendMapper.recommendDelete(memberId, reviewId);
     }
 }

--- a/src/main/resources/study/movieservice/repository/RecommendMapper.xml
+++ b/src/main/resources/study/movieservice/repository/RecommendMapper.xml
@@ -13,6 +13,7 @@
             from recommend
             where member_id = #{memberId}
             and review_id = #{reviewId}
+            and deleted=0
         )
     </select>
 
@@ -23,12 +24,11 @@
           and review_id = #{recommend.reviewId}
     </update>
 
-    <delete id="recommendDelete">
-        delete
-        from recommend
+    <update id="recommendDelete">
+        update recommend
+        set deleted=1
         where member_id = #{memberId}
           and review_id = #{reviewId}
-    </delete>
+    </update>
 
 </mapper>
-

--- a/src/main/resources/study/movieservice/repository/ReviewMapper.xml
+++ b/src/main/resources/study/movieservice/repository/ReviewMapper.xml
@@ -7,10 +7,11 @@
         values (#{movieId}, #{memberId}, #{content},#{rating}, #{likeCount}, #{disLikeCount}, current_timestamp , current_timestamp)
     </insert>
 
-    <delete id="delete">
-        delete from review
+    <update id="delete">
+        update review
+        set deleted=1
         where id = #{reviewId}
-    </delete>
+    </update>
 
     <select id="getTotalRowCount" resultType="int">
         select count (*)
@@ -18,9 +19,10 @@
     </select>
 
     <select id="getReviewList" resultType="ReviewVO">
-        select r.id as reviewId, movie_id, login_id, r.member_id as member_id, nickname, content, rating, like_count, unlike_count
+        select r.id as reviewId, movie_id, login_id, r.member_id as member_id, nickname, content, rating, like_count, dislike_count
         from review as r left join member as m
         on r.member_id = m.id
+        and r.deleted=0
         order by reviewId Desc
         limit #{startIdx}, 10
     </select>
@@ -59,6 +61,7 @@
         select rating, count(rating)
         from review
         where movie_id = #{movieId}
+            and deleted=0
         group by rating
         order by rating asc
     </select>
@@ -67,18 +70,21 @@
         select count (*)
         from review
         where movie_id = #{movieId}
+            and deleted=0
     </select>
 
     <select id="getRatingAverage" resultType="Double">
         select avg (rating)
         from review
         where movie_id = #{movieId}
+            and deleted=0
     </select>
 
     <select id="getReviewCount" resultType="int">
         SELECT COUNT(*)
         FROM review
         WHERE member_id = #{memberId}
+            and deleted=0
     </select>
 </mapper>
 


### PR DESCRIPTION
> ### 추가된점
- 기존의 delete쿼리를 deleted 칼럼값을 1로 update 하는방법으로 변경하여 처리하도록 변경하였고 그에영향받는 쿼리들의 조건문을 추가해주었습니다.
## recommendService.java
### 변경 전 
```java
    @RedissonLock(key="reviewId")
    public void recommendDelete(Recommend inputRecommend) {

        Long memberId = sessionManager.getMemberId();
        Long reviewId= inputRecommend.getReviewId();

        if (!recommendMapper.findByReviewIdAndMemberId(reviewId, memberId))
            throw new IllegalArgumentException(FAILED_RECOMMEND_REQUEST.getMessage());
        recommendMapper.recommendDelete(memberId, reviewId);
    }

```
### 변경 후 
```java
    @RedissonLock(key="reviewId")
    public void recommendDelete(Recommend inputRecommend) {

        Long memberId = sessionManager.getMemberId();
        Long reviewId= inputRecommend.getReviewId();

        if (!recommendMapper.findByReviewIdAndMemberId(reviewId, memberId))
            throw new IllegalArgumentException(FAILED_RECOMMEND_REQUEST.getMessage());

        if(inputRecommend.getRecommendState()) {
            reviewService.decreaseLikeCount(reviewId);
        }
        else{
            reviewService.decreaseDislikeCount(reviewId);
        }

        recommendMapper.recommendDelete(memberId, reviewId);
    }

```
## RecommendMapper.xml
### 변경 전 
```xml
    <delete id="recommendDelete">
        delete
        from recommend
        where member_id = #{memberId}
          and review_id = #{reviewId}
    </delete>

```
### 변경 후 
```xml
    <update id="recommendDelete">
        update recommend
        set deleted=1
        where member_id = #{memberId}
          and review_id = #{reviewId}
    </update>

```