### PR TITLE
Apply-S3#50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
 	//using aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	// S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
 	implementation 'org.json:json:20200518'
 	implementation 'org.projectlombok:lombok:1.18.22'
 

--- a/src/main/java/study/movieservice/service/MovieService.java
+++ b/src/main/java/study/movieservice/service/MovieService.java
@@ -1,5 +1,6 @@
 package study.movieservice.service;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,7 +35,7 @@ public class MovieService {
      */
     private final Integer moviePerPage;
 
-    public MovieService(MovieMapper movieMapper, PosterMapper posterMapper, FileIO fileIO, @Value("${moviePerPage}") Integer moviePerPage, ReviewMapper reviewMapper) {
+    public MovieService(MovieMapper movieMapper, PosterMapper posterMapper, @Qualifier("fileIOS3") FileIO fileIO, @Value("${moviePerPage}") Integer moviePerPage, ReviewMapper reviewMapper) {
         this.movieMapper = movieMapper;
         this.posterMapper = posterMapper;
         this.fileIO = fileIO;

--- a/src/main/java/study/movieservice/service/fileIO/FileIOS3.java
+++ b/src/main/java/study/movieservice/service/fileIO/FileIOS3.java
@@ -1,0 +1,69 @@
+package study.movieservice.service.fileIO;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+@Service
+public class FileIOS3 implements FileIO {
+
+    private final String bucket;
+    private final String accessKey;
+    private final String secretKey;
+    private final String region;
+
+    public FileIOS3(@Value("${cloud.aws.s3.bucket}") String bucket,
+                    @Value("${cloud.aws.credentials.accessKey}") String accessKey,
+                    @Value("${cloud.aws.credentials.secretKey}") String secretKey,
+                    @Value("${cloud.aws.region.static}") String region
+                    ) {
+        this.bucket = bucket;
+        this.accessKey=accessKey;
+        this.secretKey=secretKey;
+        this.region=region;
+    }
+
+    @Override
+    public String uploadFile(MultipartFile file) throws IOException {
+
+        String originalFileName = file.getOriginalFilename();
+        AmazonS3 s3Client=getS3Client();
+        ObjectMetadata objectMetadata=new ObjectMetadata();
+        ByteArrayInputStream byteArrayInputStream=getByteArrayInputStream(file,objectMetadata);
+
+        s3Client.putObject(new PutObjectRequest(bucket,originalFileName,byteArrayInputStream,objectMetadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        return s3Client.getUrl(bucket,originalFileName).toString();
+    }
+
+    private ByteArrayInputStream getByteArrayInputStream(MultipartFile file, ObjectMetadata objectMetadata) throws IOException {
+
+        byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+        objectMetadata.setContentLength(bytes.length);
+
+        return new ByteArrayInputStream(bytes);
+    }
+
+    public AmazonS3 getS3Client(){
+
+        AWSCredentials credentials=new BasicAWSCredentials(accessKey,secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/study/movieservice/service/fileIO/FileIOS3.java
+++ b/src/main/java/study/movieservice/service/fileIO/FileIOS3.java
@@ -52,6 +52,7 @@ public class FileIOS3 implements FileIO {
     private ByteArrayInputStream getByteArrayInputStream(MultipartFile file, ObjectMetadata objectMetadata) throws IOException {
 
         byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+        file.getInputStream().close();
         objectMetadata.setContentLength(bytes.length);
 
         return new ByteArrayInputStream(bytes);


### PR DESCRIPTION
> ### 변경된점
- 기존에 로컬에 포스터 이미지를 저장하는 방식에서 AWS S3에 저장하는 방식으로 변경합니다.
## MovieService.java
### 변경 전 
```java
public MovieService(MovieMapper movieMapper, PosterMapper posterMapper, FileIO fileIO, @Value("${moviePerPage}") Integer moviePerPage, ReviewMapper reviewMapper) {

```
### 변경 후 (Qualifier어노테이션 적용)
```java
public MovieService(MovieMapper movieMapper, PosterMapper posterMapper, @Qualifier("fileIOS3") FileIO fileIO, @Value("${moviePerPage}") Integer moviePerPage, ReviewMapper reviewMapper) {
```
## FileIOS3.java
### 추가된 코드
- application.properties에 aws S3관련 정보 저장
```java
@Service
public class FileIOS3 implements FileIO {

    private final String bucket;
    private final String accessKey;
    private final String secretKey;
    private final String region;

    public FileIOS3(@Value("${cloud.aws.s3.bucket}") String bucket,
                    @Value("${cloud.aws.credentials.accessKey}") String accessKey,
                    @Value("${cloud.aws.credentials.secretKey}") String secretKey,
                    @Value("${cloud.aws.region.static}") String region
                    ) {
        this.bucket = bucket;
        this.accessKey=accessKey;
        this.secretKey=secretKey;
        this.region=region;
    }

    @Override
    public String uploadFile(MultipartFile file) throws IOException {

        String originalFileName = file.getOriginalFilename();
        AmazonS3 s3Client=getS3Client();
        ObjectMetadata objectMetadata=new ObjectMetadata();
        ByteArrayInputStream byteArrayInputStream=getByteArrayInputStream(file,objectMetadata);

        s3Client.putObject(new PutObjectRequest(bucket,originalFileName,byteArrayInputStream,objectMetadata)
                .withCannedAcl(CannedAccessControlList.PublicRead));

        return s3Client.getUrl(bucket,originalFileName).toString();
    }

    private ByteArrayInputStream getByteArrayInputStream(MultipartFile file, ObjectMetadata objectMetadata) throws IOException {

        byte[] bytes = IOUtils.toByteArray(file.getInputStream());
        objectMetadata.setContentLength(bytes.length);

        return new ByteArrayInputStream(bytes);
    }

    public AmazonS3 getS3Client(){

        AWSCredentials credentials=new BasicAWSCredentials(accessKey,secretKey);

        return AmazonS3ClientBuilder.standard()
                .withCredentials(new AWSStaticCredentialsProvider(credentials))
                .withRegion(region)
                .build();
    }
}

```
